### PR TITLE
fix(docs): link learn the basics

### DIFF
--- a/website/src/components/QuickStart.js
+++ b/website/src/components/QuickStart.js
@@ -52,7 +52,7 @@ export const QuickStart = () => {
             </Terminal>
             <SubTitle>
               {' '}
-              <a className="LinkBasics" href={'docs/guides/getting-started'}>
+              <a className="LinkBasics" href={siteConfig.themeConfig.navbar.links[0].to}>
                 Learn the basics
               </a>{' '}
               or dive deeper and take a{' '}


### PR DESCRIPTION
Fixes link "Learn the basics" on main page that is part of `QuickStart` component that points to wrong URL.

### Summary

Link location.

### What is the current _bug_ behavior?

Redirects out to non existing  path.

### What is the expected _correct_ behavior?

Redirect to `docs/guides/01-the-basics/01-getting-started`.

---

## Review Checklist

### Basics

- [x] PR information has been filled
- [x] PR has been assigned
- [x] PR uses appropriate labels (`fix`)
- [x] PR has a all necessary bug-description fields filled
- [ ] PR is peer reviewed <sup>**optional**</sup>
- [x] Commits contain a meaningful commit messages and fallow syntax of [Conventional Commits](http://www.conventionalcommits.org/)
- [ ] On dependency change: `yarn.lock` file is updated and committed
- [x] `CHANGELOG.md` and references to project's version are unchanged(let [semantic-release](https://github.com/semantic-release/semantic-release) do the magic)

### Code Quality

- [x] Code is properly typed with TypeScript
- [x] Code `builds`(`yarn build`)
- [x] Code is `formatted`(`yarn test:format`)
- [x] Code is `linted`(`yarn test:lint`)
- [x] Code is unit `tested`(`yarn test:unit`)
- [x] Code is integration `tested`(`yarn test:integration`)

### Testing

- [ ] New fix is covered by unit tests
- [ ] New fix is covered by integration tests
- [x] All existing tests are still up-to-date

### After Review

- [x] Merge the PR
- [x] Delete the source branch
- [ ] Move the ticket to `done` <sup>**optional**</sup>
