### PR TITLE
fix(docs): building file paths for docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "semantic-release": "^17.0.8",
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/git": "^9.0.0",
-    "chalk": "^4.1.0"
+    "chalk": "^4.1.0",
+    "rimraf": "^3.0.2"
   },
   "scripts": {
     "explain": "./node_modules/.bin/npm-scripts-info",

--- a/website/.eveble/scripts/docs.js
+++ b/website/.eveble/scripts/docs.js
@@ -139,22 +139,22 @@ module.exports = class ConfigGenerator {
    */
   listFilesInDirRecursive(dir, list = {}, subDir = undefined) {
     const files = fs.readdirSync(dir);
-
     files.forEach((file) => {
-      const filePath = path.join(dir, file);
-      const fileStat = fs.lstatSync(filePath);
-
-      if (fileStat.isDirectory()) {
-        const subDir = file;
-        if (list[subDir] === undefined) {
-          list[subDir] = [];
-        }
-        this.listFilesInDirRecursive(filePath, list, subDir);
-      } else {
-        if (subDir !== undefined) {
-          list[subDir].push(this.normalizePathForDocusaurusConfig(filePath));
+      if (/^\./.test(file) !== true) {
+        const filePath = path.join(dir, file);
+        const fileStat = fs.lstatSync(filePath);
+        if (fileStat.isDirectory()) {
+          const dir = file;
+          if (list[dir] === undefined) {
+            list[dir] = [];
+          }
+          this.listFilesInDirRecursive(filePath, list, dir);
         } else {
-          list.push(this.normalizePathForDocusaurusConfig(filePath));
+          if (subDir !== undefined) {
+            list[subDir].push(this.normalizePathForDocusaurusConfig(filePath));
+          } else {
+            list.push(this.normalizePathForDocusaurusConfig(filePath));
+          }
         }
       }
     });

--- a/website/docs/api/globals.md
+++ b/website/docs/api/globals.md
@@ -268,9 +268,15 @@ ___
 
 ###  isMochaInWatchMode
 
-▸ **isMochaInWatchMode**(): *boolean*
+▸ **isMochaInWatchMode**(`nodeProcess`: Process): *boolean*
 
 Evaluates if Mocha is running in watch('--watch') mode.
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`nodeProcess` | Process | Instance of `NodeJS.Process`. |
 
 **Returns:** *boolean*
 

--- a/website/src/components/QuickStart.js
+++ b/website/src/components/QuickStart.js
@@ -34,25 +34,17 @@ export const QuickStart = () => {
           <Title className="package--description">Quick Start</Title>
           <Description>
             <SubTitle>
-              a) Add library to dependencies in existing project:
+              Add library to dependencies in existing project:
             </SubTitle>
             <Terminal className="terminal">
-              <Code>yarn add {siteConfig.title}</Code>
-            </Terminal>
-            <SubTitle>
-              b) Use our boilerplate project to create a new one:
-            </SubTitle>
-            <Terminal className="terminal">
-              <Code>
-                git clone https://github.com/eveble/eveble-boilerplate
-              </Code>
-              <Code>cd eveble-boilerplate</Code>
-              <Code>yarn install</Code>
-              <Code>yarn add {siteConfig.title}</Code>
+              <Code>npm install {siteConfig.title}</Code>
             </Terminal>
             <SubTitle>
               {' '}
-              <a className="LinkBasics" href={siteConfig.themeConfig.navbar.links[0].to}>
+              <a
+                className="LinkBasics"
+                href={siteConfig.themeConfig.navbar.links[0].to}
+              >
                 Learn the basics
               </a>{' '}
               or dive deeper and take a{' '}


### PR DESCRIPTION
This PR fixes building file paths for documentation..

### Summary

Fix building file paths for documentation on subdirectories.

### What is the current _bug_ behavior?

Generating file paths for nested subdirectories  like the one over `./website/docs/guides/x` will cause `./website/.eveble/scripts/docs.js` to fail during Docusaurus `npm run start`.

---

## Review Checklist

### Basics

- [x] PR information has been filled
- [x] PR has been assigned
- [x] PR uses appropriate labels (`fix`)
- [x] PR has a all necessary bug-description fields filled
- [ ] PR is peer reviewed <sup>**optional**</sup>
- [x] Commits contain a meaningful commit messages and fallow syntax of [Conventional Commits](http://www.conventionalcommits.org/)
- [x] On dependency change: `yarn.lock` file is updated and committed
- [x] `CHANGELOG.md` and references to project's version are unchanged(let [semantic-release](https://github.com/semantic-release/semantic-release) do the magic)

### Code Quality

- [x] Code is properly typed with TypeScript
- [x] Code `builds`(`yarn build`)
- [x] Code is `formatted`(`yarn test:format`)
- [x] Code is `linted`(`yarn test:lint`)
- [x] Code is unit `tested`(`yarn test:unit`)
- [x] Code is integration `tested`(`yarn test:integration`)

### Testing

- [ ] New fix is covered by unit tests
- [ ] New fix is covered by integration tests
- [x] All existing tests are still up-to-date

### After Review

- [x] Merge the PR
- [x] Delete the source branch
- [ ] Move the ticket to `done` <sup>**optional**</sup>